### PR TITLE
解决了DateTimePicker默认值中的hour 或minute 为0时发生的异常错误

### DIFF
--- a/android-pickers/src/main/java/cn/addapp/pickers/picker/DateTimePicker.java
+++ b/android-pickers/src/main/java/cn/addapp/pickers/picker/DateTimePicker.java
@@ -837,8 +837,8 @@ public class DateTimePicker extends WheelPicker {
             public int compare(Object lhs, Object rhs) {
                 String lhsStr = lhs.toString();
                 String rhsStr = rhs.toString();
-                lhsStr = lhsStr.startsWith("0") ? lhsStr.substring(1) : lhsStr;
-                rhsStr = rhsStr.startsWith("0") ? rhsStr.substring(1) : rhsStr;
+//                lhsStr = lhsStr.startsWith("0") ? lhsStr.substring(1) : lhsStr;
+//                rhsStr = rhsStr.startsWith("0") ? rhsStr.substring(1) : rhsStr;
                 return Integer.parseInt(lhsStr) - Integer.parseInt(rhsStr);
             }
         });


### PR DESCRIPTION
 picker.setSelectedItem(2018,6,16,0,0); 凡是hour 和minute为0就会报错，因为传入的值是Int类型，所以没有必要去除‘0’

